### PR TITLE
fix isNewline cannot be read from php 5.3

### DIFF
--- a/src/Webcreate/Conveyor/Subscriber/BuilderSubscriber.php
+++ b/src/Webcreate/Conveyor/Subscriber/BuilderSubscriber.php
@@ -22,7 +22,7 @@ class BuilderSubscriber implements EventSubscriberInterface
 {
     protected $io;
     protected $showProgress = false;
-    protected $needsNewline = false;
+    public $needsNewline = false;
 
     public function __construct(IOInterface $io)
     {


### PR DESCRIPTION
php 5.3 cannot access protected properties in closure thats why i get here:

```
PHP Fatal error:  Cannot access protected property Webcreate\Conveyor\Subscriber\BuilderSubscriber::$needsNewline in phar:///usr/local/sbin/conveyor.phar/src/Webcreate/Conveyor/Subscriber/BuilderSubscriber.php on line 72
```

You probably want a test for that, can you help me where to start?
