### PR TITLE
Using array notation to set a file now uses the same logic as add()

### DIFF
--- a/src/Webcreate/Conveyor/Util/FileCollection.php
+++ b/src/Webcreate/Conveyor/Util/FileCollection.php
@@ -191,11 +191,7 @@ class FileCollection implements \IteratorAggregate, \Countable, \ArrayAccess
 
     public function offsetSet($offset, $value)
     {
-        if (is_null($offset)) {
-            $this->files[] = $value;
-        } else {
-            $this->files[$offset] = $value;
-        }
+        $this->add($value);
     }
 
     public function offsetUnset($offset)

--- a/tests/Webcreate/Conveyor/Util/FileCollectionTest.php
+++ b/tests/Webcreate/Conveyor/Util/FileCollectionTest.php
@@ -57,6 +57,16 @@ class FileCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('src/Webcreate/Conveyor/Conveyor.php', $files);
     }
 
+    public function testAddArrayNotation()
+    {
+        $collection = new Webcreate\Conveyor\Util\FileCollection(__DIR__ . '/../../../../');
+        $collection[] = 'vendor';
+
+        $files = iterator_to_array($collection);
+
+        $this->assertContains('vendor/autoload.php', $files);
+    }
+
     public function testRemove()
     {
         $collection = new Webcreate\Conveyor\Util\FileCollection(__DIR__ . '/../../../../');


### PR DESCRIPTION
When using array notation in the FileCollection to add a file/directory, it is just added to the array, bypassing the logic in the `add` method. This causes problem when adding directories for example. This pull request fixes this by calling the `add` method from the `offsetSet` method.

It could be argued that the `$offset` parameter is ignored here, but looking at the rest of the class, the `files` array uses numeric keys everywhere so I doubt this is an issue.
