### PR TITLE
Don't halt deploy when a certain target has nothing to deploy

### DIFF
--- a/src/Webcreate/Conveyor/Exception/EmptyChangesetException.php
+++ b/src/Webcreate/Conveyor/Exception/EmptyChangesetException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Webcreate\Conveyor\Exception;
+
+class EmptyChangesetException extends \Exception
+{ 
+}

--- a/src/Webcreate/Conveyor/Stage/BuildFilelistStage.php
+++ b/src/Webcreate/Conveyor/Stage/BuildFilelistStage.php
@@ -12,6 +12,7 @@
 namespace Webcreate\Conveyor\Stage;
 
 use Webcreate\Conveyor\Context;
+use Webcreate\Conveyor\Exception\EmptyChangesetException;
 use Webcreate\Conveyor\Repository\Repository;
 use Webcreate\Conveyor\Util\FileCollection;
 use Webcreate\Vcs\Common\Status;
@@ -96,9 +97,8 @@ class BuildFilelistStage extends AbstractStage
         $filesModified->remove('conveyor.yml');
 
         // validate result, throw exception when we have nothing to deploy
-        // @todo improve this, throwing exceptions is crap!
         if (0 === count($filesModified) && 0 === count($filesDeleted)) {
-            throw new \RuntimeException('Nothing to deploy, this should not have happend');
+            throw new EmptyChangesetException();
         }
 
         $context->setFilesModified($filesModified);


### PR DESCRIPTION
When you deploy to a group and a certain target has nothing to deploy, the other targets were not deployed, because an exception was thrown. This PR introduces a EmptyChangesetException which is safely handled during the deploy process.